### PR TITLE
fix Expand-Archive to use correct library

### DIFF
--- a/Get-ZimmermanTools.ps1
+++ b/Get-ZimmermanTools.ps1
@@ -433,7 +433,7 @@ foreach ($td in $toDownload)
 		if ($name.endswith("zip"))
 		{
 			
-			Expand-Archive -Path $destFile -DestinationPath $tempDest -Force
+			Microsoft.PowerShell.Archive\Expand-Archive -Path $destFile -DestinationPath $tempDest -Force
 		}
 		
 		$downloadedOK += $td


### PR DESCRIPTION
Expand-Archive giving syntax error in PowerShell v5.1 (A parameter cannot be found that matches parameter name 'DestinationPath') 

I've added Microsoft.PowerShell.Archive to use it from the correct library.